### PR TITLE
Always create output directory

### DIFF
--- a/documentjs.js
+++ b/documentjs.js
@@ -247,7 +247,7 @@ steal(	'steal/generate/ejs.js',
 					options.out = scripts+"/docs";
 				}
 			}
-
+			new java.io.File(options.out).mkdir();
 			scripts = DocumentJS.getScripts(scripts)
 		}
 		// an array of folders


### PR DESCRIPTION
I added a fix for issue #4 which will always create the output directory.
