### PR TITLE
Removed the duplicate 'Javascript' text in the page heading (summary.ejs).

### DIFF
--- a/jmvcdoc/summary.ejs
+++ b/jmvcdoc/summary.ejs
@@ -38,7 +38,7 @@
 </li>
 </ul>
 </div>
-<div class="logo-text"><a href='http://javascriptmvc.com'>JavaScript<img src='../documentjs/jmvcdoc/images/logo80x30.png' class="logo-image"/></a></div>
+<div class="logo-text"><a href='http://javascriptmvc.com'><img src='../documentjs/jmvcdoc/images/logo80x30.png' class="logo-image"/></a></div>
 </div>
 <div class="bottomCorner">
 	<div class="right"></div>


### PR DESCRIPTION
The text 'Javascript' is included in logo80x30.png image, so the text in the anchor has been removed.
