### PR TITLE
Running Document.getScripts on DocumentJS array first arg like we do for string

### DIFF
--- a/documentjs.js
+++ b/documentjs.js
@@ -254,7 +254,8 @@ steal(	'steal/generate/ejs.js',
 			}
 			steal.File(options.out).mkdir();
 			scripts = DocumentJS.getScripts(scripts)
-    } else if(scripts instanceof Array){
+		} else if(scripts instanceof Array){
+			steal.File(options.out).mkdir();
 			trueScriptsArr = [];
 			for(idx in scripts) {
 				files = DocumentJS.getScripts(scripts[idx]);


### PR DESCRIPTION
This would allow a consistant behavior between calling DocumentJS with a string and with an Array. The problem was that when passing it an app name as a string, it automatically loaded all the right files, but there was no way of doing the same for multiple directory. This is especially useful when building the docs of an app and its libraries: DocumentJS([ 'my_app', 'my_library' ], { out: 'mydocs' });

Like us, many companies build view helpers, models and other classes to be reusable from project to project. This change would allow them and us to compose their documentation's contents as they see fit.
