### PR TITLE
Added ids to signatures so anchors will work

### DIFF
--- a/site/default/templates/signature.mustache
+++ b/site/default/templates/signature.mustache
@@ -1,4 +1,4 @@
-<h2>{{{makeSignature code params returns context}}}
+<h2 id="{{makeSignatureId code params returns context}}">{{{makeSignature code params returns context}}}
 {{#if release}}<span class="pull-right release">{{release}}</span>{{/if}}</h2>
 <div class="signature-wrapper">
 {{{docLinks description}}}

--- a/site/utilities.js
+++ b/site/utilities.js
@@ -584,7 +584,7 @@ steal('../libs/underscore.js', 'steal', 'steal/rhino/json.js', function (_, stea
 				
 				return txt
 			},
-			makeSignature: function( code){
+			makeSignature: function(code){
 				if(code){
 					return esc(code);
 				}
@@ -620,6 +620,9 @@ steal('../libs/underscore.js', 'steal', 'steal/rhino/json.js', function (_, stea
 				
 				return sig;
 				
+			},
+			makeSignatureId: function(code){
+				return "sig_" + helpers.makeSignature(code).replace(/\s/g,"").replace(/[^\w]/g,"_");
 			}
 		}
 		if(typeof config.helpers == "function"){


### PR DESCRIPTION
Linking to a signature in documentation is now possible (and clicking on table of contents link to signature will work)

Fixes #51 
