### PR TITLE
(RE #77) Add newline to end of demo DIV tag, to preserve the newline on ...

### DIFF
--- a/lib/tags/demo.js
+++ b/lib/tags/demo.js
@@ -42,7 +42,7 @@
 	
 				var cd =  ( curData && curData.length !== 2),
 					cw = (currentWrite || "body"),
-					html = "<div class='demo_wrapper' data-demo-src='" + src + "'" + heightAttr + "></div>";
+					html = "<div class='demo_wrapper' data-demo-src='" + src + "'" + heightAttr + "></div>\n";
 				
 				
 				// use curData if it is not an array


### PR DESCRIPTION
...`@demo` tags. This allows the markdown parser to properly handle the DIV tag and any text that follows.

http://daringfireball.net/projects/markdown/syntax#html
