### PR TITLE
Fix error thrown when a @return tag is empty

### DIFF
--- a/lib/tags/return.js
+++ b/lib/tags/return.js
@@ -46,7 +46,7 @@ module.exports = {
 		var children = typer.tree(line);
 		
 		// check the format
-		if(!children.length >= 2 || !children[1].children) {
+		if(!children.length >= 2 || !children[1] || !children[1].children) {
 			printError();
 			return;
 		}

--- a/lib/tags/return_test.js
+++ b/lib/tags/return_test.js
@@ -1,17 +1,24 @@
 var ret = require("./return"),
 	assert = require("assert");
-	
+
 describe("documentjs/lib/tags/return",function(){
-	
+
 	it("@return",function(){
 		var obj = {}
 		ret.add.call(obj,"@return {String} a description");
-		
+
 		assert.deepEqual(obj.returns,{
 			description: "a description",
 			types: [{type: "String"}]
 		});
 	});
-	
-	
+
+	it("gracefully handles empty expression", function(){
+		var obj = {}
+		try {
+			ret.add.call(obj, "@return");
+		} catch (e) {
+			assert.ok(false, 'error thrown');
+		}
+	});
 });


### PR DESCRIPTION
If you have an empty `@return` tag, documentjs crashes with the error:

`"TypeError: Cannot read property 'children' of undefined"`

The fix is to make sure there is a second child before trying to work on its children.