### PR TITLE
Copy static/resources directory without changing it if it exists

### DIFF
--- a/docs/guides/customizing.md
+++ b/docs/guides/customizing.md
@@ -183,6 +183,10 @@ behavior:
 	        ...
 	    });
 
+### Adding Additional Static Resources
+
+If you'd like to add additional static resources, simply create a `resources` directory in the `siteConfig.static` folder. The contents of the `resources` directory will be copied in its entirety without any additional processing.
+
 ## Writing your own generator
 
 You can create your own [documentjs.generator generator] module which gives you

--- a/site/default/static/build.js
+++ b/site/default/static/build.js
@@ -50,7 +50,7 @@ module.exports = function(options, folders){
 				fsx.copy( path.join(folders.build,"html5shiv.js"), path.join(folders.dist,"html5shiv.js")),
 					
 				copyDir("fonts"),
-				
+				copyDir("resources"),
 				copyDir("img"),
 				copyDir("templates")
 			]);


### PR DESCRIPTION
This will allow creation of additional static resources (e.g. html demo files) that will be copied over without additional generation (the same way the 'img' directory is copied).