### PR TITLE
Include a link to JSBin in the generated demo.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+; Unix-style newlines
+[*]
+end_of_line = LF
+indent_style = tab
+indent_size = 4

--- a/lib/tags/demo.js
+++ b/lib/tags/demo.js
@@ -1,60 +1,88 @@
-	/**
-	 * @constructor documentjs.tags.demo @demo
-	 * @parent documentjs.tags 
-	 * 
-	 * @description Placeholder for an application demo.
-	 * 
-	 * @signature `@demo SRC [HEIGHT]`
-	 * 
-	 * @codestart javascript
-	 * /**
-	 *  * @demo can/control/control.html 300
-	 *  *|
-	 * @codeend
-	 * 
-	 * @param {String} SRC The source of the html page.
-	 * @param {Number} [HEIGHT] The height of the html page. If
-	 * a height is not provided, the height is determined as
-	 * the content of the body.
-	 * 
-	 * @body
-	 * 
-	 * ## Specifying the HTML and JS source
-	 * 
-	 * By default, `@demo` uses the html of the body minus
-	 * any script tags as the HTML source. This can 
-	 * be changed by:
-	 * 
-	 *  - Adding an element with `id="demo-html"` or 
-	 *    setting `window.DEMO_HTML` to the source text.
-	 *  - Adding `id="demo-source"` to a script tag or
-	 *    setting `window.DEMO_SOURCE` to the source JS.
-	 */
-	module.exports = {
-		add: function(  line, curData, scope, objects, currentWrite ) {
-			
-			var m = line.match(/^\s*@demo\s*([\w\.\/\-\$]*)\s*([\w]*)/)
-			if ( m ) {
-				var src = m[1] ? m[1].toLowerCase() : '';
-				var heightAttr = m[2].length > 0 ? " data-demo-height='" + m[2] + "'" : '';
-				
-				
-	
-				var cd =  ( curData && curData.length !== 2),
-					cw = (currentWrite || "body"),
-					html = "<div class='demo_wrapper' data-demo-src='" + src + "'" + heightAttr + "></div>\n";
-				
-				
-				// use curData if it is not an array
-				var useCurData = cd && (typeof curData.description === "string") && !curData.body;
-	
-				if(useCurData) {
-					
-					curData.description += html;
-				} else {
-					this.body += html;
-				}
-				
+/**
+ * @constructor documentjs.tags.demo @demo
+ * @parent documentjs.tags
+ *
+ * @description Placeholder for an application demo.
+ *
+ * @signature `@demo SRC [HEIGHT] [JSBIN]`
+ *
+ * @codestart javascript
+ * /**
+ *  * @demo can/control/control.html 300 +jsbin
+ *  *|
+ * @codeend
+ *
+ * @param {String} SRC The source of the html page.
+ * @param {Number} [HEIGHT] The height of the html page. If
+ * a height is not provided, the height is determined as
+ * the content of the body.
+ * @param {String} [JSBIN] A flag to display a link that
+ * will load the demo code in [JS Bin](jsbin.com); by default
+ * the link will not be shown. You can pass the flag (`+jsbin`)
+ * as the second argument if [HEIGHT] is not provided, e.g:
+ *
+ * 	@codestart javascript
+ * 	/**
+ * 	 * @demo can/control/control.html +jsbin
+ * 	 *|
+ * 	@codeend
+ *
+ * @body
+ *
+ * ## Specifying the HTML and JS source
+ *
+ * By default, `@demo` uses the html of the body minus
+ * any script tags as the HTML source. This can
+ * be changed by:
+ *
+ *  - Adding an element with `id="demo-html"` or
+ *    setting `window.DEMO_HTML` to the source text.
+ *  - Adding `id="demo-source"` to a script tag or
+ *    setting `window.DEMO_SOURCE` to the source JS.
+ */
+module.exports = {
+	add: function(  line, curData, scope, objects, currentWrite ) {
+		var jsbinFlag = '+jsbin';
+		var matches = line.match(/^\s*@demo\s*([\w\.\/\-\$]*)\s*([\w]*)\s*(\+jsbin)*/);
+
+		// signatures to support
+		// @demo path/to/demo
+		// @demo path/to/demo 400
+		// @demo path/to/demo +jsbin
+		// @demo path/to/demo 400 +jsbin
+		if (matches) {
+			var src = matches[1] ? matches[1].toLowerCase() : '';
+			var height = Number(matches[2]) > 0 ? matches[2] : 0;
+			var includeJsbinLink = matches[2] === jsbinFlag || matches[3] === jsbinFlag;
+
+			var htmlStart = '<div class="demo_wrapper"';
+			var htmlEnd = '></div>\n';
+
+			if (src) {
+				htmlStart += ' data-demo-src="' + src + '"';
+			}
+
+			if (height) {
+				htmlStart += ' data-demo-height="' + height + '"';
+			}
+
+			if (includeJsbinLink) {
+				htmlStart += ' data-jsbin-link="true"';
+			}
+
+			var cd = (curData && curData.length !== 2);
+			var cw = (currentWrite || "body");
+			var html = htmlStart + htmlEnd;
+
+			// use curData if it is not an array
+			var useCurData = cd && (typeof curData.description === "string") && !curData.body;
+
+			if (useCurData) {
+				curData.description += html;
+			}
+			else {
+				this.body += html;
 			}
 		}
-	};
+	}
+};

--- a/lib/tags/demo_test.js
+++ b/lib/tags/demo_test.js
@@ -1,0 +1,51 @@
+var assert = require('assert');
+var demo = require('./demo');
+
+describe("documentjs/lib/tags/demo", function(){
+
+	var obj;
+
+	beforeEach(function(){
+		obj = { body: '' };
+	});
+
+	it("basic add with demo source",function(){
+		demo.add.call(obj,"@demo path/to/demo");
+
+		assert(obj.body.match(/data-demo-src=\"path\/to\/demo\"/),
+			'generated html should include data-demo-src attribute');
+	});
+
+	it("basic add with demo source and height", function(){
+		demo.add.call(obj,"@demo path/to/demo 400");
+
+		assert(obj.body.match(/data-demo-src=\"path\/to\/demo\"/),
+			'generated html should include data-demo-src attribute');
+
+		assert(obj.body.match(/data-demo-height=\"400\"/),
+			'generated html should include data-demo-height attribute');
+	});
+
+	it("basic add with demo source and jsbin flag", function(){
+		demo.add.call(obj,"@demo path/to/demo +jsbin");
+
+		assert(obj.body.match(/data-demo-src=\"path\/to\/demo\"/),
+			'generated html should include data-demo-src attribute');
+
+		assert(obj.body.match(/data-jsbin-link="true"/),
+			'generated html should include data-jsbin-link attribute');
+	});
+
+	it("basic add with demo source height, and jsbin flag", function(){
+		demo.add.call(obj,"@demo path/to/demo 400 +jsbin");
+
+		assert(obj.body.match(/data-demo-src=\"path\/to\/demo\"/),
+			'generated html should include data-demo-src attribute');
+
+		assert(obj.body.match(/data-demo-height=\"400\"/),
+			'generated html should include data-demo-height attribute');
+
+		assert(obj.body.match(/data-jsbin-link="true"/),
+			'generated html should include data-jsbin-link attribute');
+	});
+});

--- a/lib/tags/tags_tests.js
+++ b/lib/tags/tags_tests.js
@@ -15,3 +15,4 @@ require("./param_test");
 require("./property_test");
 require("./return_test");
 require("./typedef_test");
+require("./demo_test");

--- a/site/default/static/demo_frame.js
+++ b/site/default/static/demo_frame.js
@@ -1,89 +1,138 @@
-steal("can/control","./demo_frame.mustache!","jquery","can/observe","./prettify.js",function(Control,demoFrameMustache,$){
-	
-	
+steal(
+	"can/control",
+	"./demo_frame.mustache!",
+	"jquery",
+	"can/observe",
+	"./prettify.js",
+	function(Control, demoFrameMustache, $){
 
-return can.Control.extend({
-	init: function() {
-		
-		var docConfig = window.docConfig || {};
-		// Render out the demo container.
-		this.element.html(demoFrameMustache( {demoSrc: (docConfig.demoSrcRoot || ".." )+'/' + this.element.data('demoSrc')}));
+		var jsbinBaseUrl = "http://jsbin.com/?html,js,output";
 
-		// Start with the demo tab showing.
-		this.showTab('demo');
+		return can.Control.extend({
+			init: function() {
+				var docConfig = window.docConfig || {};
+				var demoSrcRoot = docConfig.demoSrcRoot || "..";
+				var demoSrc = demoSrcRoot + "/" + this.element.data("demoSrc");
 
-		// When the iframe loads, grab the HTML and JS and fill in the other tabs.
-		var self = this;
-		var iFrame = this.element.find("iframe");
-		iFrame.load(function() {
-			var demoEl = this.contentDocument.getElementById('demo-html'),
-				sourceEl = this.contentDocument.getElementById('demo-source')
+				// Render out the demo container.
+				this.element.html(demoFrameMustache({demoSrc: demoSrc}));
 
-			var html = demoEl ? demoEl.innerHTML : this.contentWindow.DEMO_HTML;
-			
-			if(!html) {
-				// try to make from body
-				var clonedBody = $(this.contentDocument.body).clone();
-				clonedBody.find("script").each(function(){
-					if(!this.type || this.type.indexOf("javascript") >= 0){
-						$(this).remove()
+				// Start with the demo tab showing.
+				this.showTab("demo");
+
+				// When the iframe loads, grab the HTML and JS and fill in the other tabs.
+				var self = this;
+				var iFrame = this.element.find("iframe");
+
+				iFrame.load(function() {
+					var clonedBody;
+					var demoEl = this.contentDocument.getElementById("demo-html");
+					var	sourceEl = this.contentDocument.getElementById("demo-source");
+					var html = demoEl ? demoEl.innerHTML : this.contentWindow.DEMO_HTML;
+
+					if(!html) {
+						// try to make from body
+						clonedBody = $(this.contentDocument.body).clone();
+						clonedBody.find("script").each(function(){
+							if(!this.type || this.type.indexOf("javascript") >= 0){
+								$(this).remove();
+							}
+						});
+						clonedBody.find("style").remove();
+						html = $.trim( clonedBody.html() );
 					}
+
+					var prettyHtml = self.prettify(html);
+					self.element.find("[data-for=html] > pre").html(prettyHtml);
+
+					var source = sourceEl ? sourceEl.innerHTML : this.contentWindow.DEMO_SOURCE;
+					if(!source){
+						var scripts = $(this.contentDocument.body).find("script:not([src])");
+						// get the first one that is JS
+						for(var i = 0, len = scripts.length; i < len ; i++){
+							if(!scripts[i].type || scripts[i].type.indexOf("javascript") >= 0){
+								source =  scripts[i].innerHTML;
+							}
+						}
+					}
+
+					source = $.trim(source);
+					var prettySource = self.prettify(source.replace(/\t/g,"  "));
+					if(prettySource.length) {
+						self.element.find("[data-for=js] > pre").html(prettySource);
+						self.element.find("[data-tab=js]").show();
+					}
+
+					clonedBody = $(this.contentDocument.body).clone();
+					self.appendJsbinLink(clonedBody, source);
+
+					var resizeIframe = function(){
+						// The following was called to make it possible to shrink the size of the demo.
+						// This feature was removed because it broke the tooltip demo on can.view.attr's page
+						// iFrame.height(0);
+						iFrame.height($(iFrame).contents().height());
+						setTimeout( arguments.callee, 1000 );
+					};
+
+					resizeIframe();
 				});
-				clonedBody.find("style").remove();
-				html = $.trim( clonedBody.html() );
+			},
+			".tab click": function(el, ev) {
+				this.showTab(el.data("tab"));
+			},
+			showTab: function(tabName) {
+				this.element
+					.find(".tab").removeClass("active").end()
+					.find(".tab-content").hide().end()
+					.find(".tab[data-tab=" + tabName + "]").addClass("active").end()
+					.find("[data-for=" + tabName + "]").show();
+			},
+			prettify: function(unescaped) {
+				return prettyPrintOne(unescaped.replace(/</g, "&lt;"));
+			},
+			appendJsbinLink: function(body, source) {
+				// from https://github.com/sindresorhus/is-absolute-url
+				var isAbsoluteUrl = function(url) {
+					return /^(?:\w+:)?\/\//.test(url);
+				};
+
+				var relativeToAbsolute = function(relPath) {
+					var element = document.createElement("span");
+					element.innerHTML = '<a href="' + relPath + '">&nbsp;</a>';
+					return element.firstChild.href;
+				};
+
+				var checkUrlInAttr = function(attr) {
+					return function() {
+						var $el = $(this);
+						var val = $el.attr(attr);
+
+						if (!isAbsoluteUrl(val)) {
+							$el.attr(attr, relativeToAbsolute(val));
+						}
+					};
+				};
+
+				// remove from the body any script tag that might contain JS
+				// code and transforms relative urls to absolute urls.
+				body.find("style").remove().end()
+					.find("#demo-source").remove().end()
+					.find("script").not("[type]").not("[src]").remove().end()
+					.find("script[type*='javascript']").remove().end()
+					.find("[src]").each(checkUrlInAttr("src")).end()
+					.find("[href]").each(checkUrlInAttr("href"));
+
+				var sanitizedHtml = $.trim(body.html());
+
+				this.element.find(".jsbin_link_wrapper").html($("<a>", {
+					target: "_blank",
+					html: "Open in JS Bin.",
+					href: jsbinBaseUrl + "&" + $.param({
+						js: source,
+						html: "<body>" + sanitizedHtml + "</body>"
+					})
+				}));
 			}
-
-			var source = sourceEl ? sourceEl.innerHTML : this.contentWindow.DEMO_SOURCE;
-			if(!source){
-				var scripts = $(this.contentDocument.body).find("script:not([src])");
-				// get the first one that is JS
-				for(var i =0; i < scripts.length; i++){
-					if(!scripts[i].type || scripts[i].type.indexOf("javascript") >= 0){
-						source =  scripts[i].innerHTML
-					}
-				}
-				
-			}
-			source = $.trim(source);
-
-			self.element.find('[data-for=html] > pre').html(self.prettify(html));
-
-			var prettySource = self.prettify( source.replace(/\t/g,"  ") );
-			if(prettySource.length) {
-				self.element.find('[data-for=js] > pre').html(prettySource);
-				self.element.find('[data-tab=js]').show();
-			}
-
-
-			//prettyPrint();
-	
-			var resizeIframe = function(){
-				
-				// The following was called to make it possible to shrink the size of the demo.  
-				// This feature was removed because it broke the tooltip demo on can.view.attr's page
-				// iFrame.height(0);
-				iFrame.height($(iFrame).contents().height());
-				setTimeout( arguments.callee, 1000 )
-			};
-			
-			resizeIframe()
-			
-			
-			
 		});
-	},
-	'.tab click': function(el, ev) {
-		this.showTab(el.data('tab'));
-	},
-	showTab: function(tabName) {
-		$('.tab', this.element).removeClass('active');
-		$('.tab-content', this.element).hide();
-		$('.tab[data-tab=' + tabName + ']', this.element).addClass('active');
-		$('[data-for=' + tabName + ']', this.element).show();
-	},
-	prettify: function(unescaped) {
-		return prettyPrintOne(unescaped.replace(/</g, '&lt;'));
 	}
-});
-
-});
+);

--- a/site/default/static/demo_frame.js
+++ b/site/default/static/demo_frame.js
@@ -9,13 +9,13 @@ steal(
 		var jsbinBaseUrl = "http://jsbin.com/?html,js,output";
 
 		return can.Control.extend({
-			init: function() {
+			init: function(element, options) {
 				var docConfig = window.docConfig || {};
 				var demoSrcRoot = docConfig.demoSrcRoot || "..";
-				var demoSrc = demoSrcRoot + "/" + this.element.data("demoSrc");
+				var demoSrc = demoSrcRoot + "/" + options.demoSrc;
 
 				// Render out the demo container.
-				this.element.html(demoFrameMustache({demoSrc: demoSrc}));
+				this.element.html(demoFrameMustache({ demoSrc: demoSrc }));
 
 				// Start with the demo tab showing.
 				this.showTab("demo");
@@ -23,6 +23,11 @@ steal(
 				// When the iframe loads, grab the HTML and JS and fill in the other tabs.
 				var self = this;
 				var iFrame = this.element.find("iframe");
+
+				// set the iframe height if provided.
+				if (options.demoHeight) {
+					iFrame.height(options.demoHeight);
+				}
 
 				iFrame.load(function() {
 					var clonedBody;
@@ -63,8 +68,10 @@ steal(
 						self.element.find("[data-tab=js]").show();
 					}
 
-					clonedBody = $(this.contentDocument.body).clone();
-					self.appendJsbinLink(clonedBody, source);
+					if (options.includeJsbinLink) {
+						clonedBody = $(this.contentDocument.body).clone();
+						self.appendJsbinLink(clonedBody, source);
+					}
 
 					var resizeIframe = function(){
 						// The following was called to make it possible to shrink the size of the demo.
@@ -126,7 +133,7 @@ steal(
 
 				this.element.find(".jsbin_link_wrapper").html($("<a>", {
 					target: "_blank",
-					html: "Open in JS Bin.",
+					html: '<i class="icon-breakout"></i>Open in JS Bin',
 					href: jsbinBaseUrl + "&" + $.param({
 						js: source,
 						html: "<body>" + sanitizedHtml + "</body>"

--- a/site/default/static/demo_frame.mustache
+++ b/site/default/static/demo_frame.mustache
@@ -13,4 +13,6 @@
 	<div class="tab-content" data-for="js">
 		<pre class="prettyprint lang-js"></pre>
 	</div>
+
+	<div class="jsbin_link_wrapper"></div>
 </div>

--- a/site/default/static/demo_frame.mustache
+++ b/site/default/static/demo_frame.mustache
@@ -4,6 +4,7 @@
 		<li class="tab" data-tab="html">HTML</li>
 		<li class="tab" data-tab="js" style="display:none;">JS</li>
 	</ul>
+	<span class="jsbin_link_wrapper"></span>
 	<div class="tab-content" data-for="demo">
 		<iframe src="{{demoSrc}}"/>
 	</div>
@@ -13,6 +14,4 @@
 	<div class="tab-content" data-for="js">
 		<pre class="prettyprint lang-js"></pre>
 	</div>
-
-	<div class="jsbin_link_wrapper"></div>
 </div>

--- a/site/default/static/frame_helper.js
+++ b/site/default/static/frame_helper.js
@@ -11,11 +11,11 @@ steal('can/control','jquery','./demo_frame.js',function(Control, $,DemoFrame){
 			$('.iframe_wrapper', this.element).each(function() {
 				var wrapper = $(this),
 					iframe = $('<iframe src="../' + wrapper.data('iframeSrc') + '">');
-				
+
 				if(wrapper.data('iframeHeight')) {
 					iframe.height(wrapper.data('iframeHeight'));
 				}
-	
+
 				wrapper.append(iframe);
 			});
 		},
@@ -24,13 +24,12 @@ steal('can/control','jquery','./demo_frame.js',function(Control, $,DemoFrame){
 			// <div class="demo_wrapper" data-demo-src="can/control/control.html"></div>
 			$('.demo_wrapper', this.element).each(function() {
 				var wrapper = $(this);
-				new DemoFrame(wrapper);
-				
-				if(wrapper.data('demoHeight')) {
-					iframe.height(wrapper.data('demoHeight'));
-				}
+				new DemoFrame(wrapper, {
+					demoSrc: wrapper.data('demoSrc'),
+					demoHeight: wrapper.data('demoHeight'),
+					includeJsbinLink: wrapper.data('jsbinLink')
+				});
 			});
 		}
 	});
-
-})
+});

--- a/site/default/static/styles/api.less
+++ b/site/default/static/styles/api.less
@@ -43,13 +43,13 @@
     border-bottom: 1px solid @fog;
     .heading {
     	position: relative;
-    	margin: 0; 
+    	margin: 0;
     	h1 {
     	  margin: 0;
     	  display: inline-block;
         max-width: 550px;
         word-wrap: break-word;
-    	}		  
+    	}
       .module {
       	position: absolute;
       	right: 0;
@@ -84,7 +84,7 @@
     ul.links {
     	margin-bottom: 16px;
     }
-    .links, 
+    .links,
     .tags {
       list-style: none;
       margin: 0;
@@ -131,7 +131,7 @@
 
 
 // Docs General Styles
-.docs {	
+.docs {
   .content.docs {
     width: 662px;
     margin-top: 20px;
@@ -142,7 +142,7 @@
     border-bottom-style: none;
     font-family: Arial, Helvetica, Geneva, sans-serif;
     border-radius: 0 5px 5px 0;
-    
+
     ul, ol:not(.linenums) {
     	margin-left: 0;
     	.p;
@@ -287,7 +287,7 @@
       font-style: normal;
       float: right;
     }
-    
+
     code {
       background-color: transparent;
       color: @clear;
@@ -311,7 +311,7 @@
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
-  
+
   a.sig {
     text-decoration: none;
     color: @night;
@@ -326,7 +326,7 @@
       color: black;
     }
   }
-  
+
   p {
     color: @thunderStorm;
     line-height: 15px;
@@ -340,7 +340,7 @@
 /**
 * @styles parameters-returns Parameters and Returns
 *
-* @description 
+* @description
 * Parameters and returns are shown inside of `.signature` but their styles are not dependant on it.
 *
 * @demo demos/parameters-returns.html
@@ -391,7 +391,7 @@
   .parameters .options {
     margin-right: 50px;
   }
-  .parameters .options .option, 
+  .parameters .options .option,
   .returns .options .option {
     margin: 0 -10px 15px;
     list-style-type: none;
@@ -410,7 +410,7 @@
 }
 .docs .parameters .description,
 .docs .returns .description {
-  padding-bottom: 15px; 
+  padding-bottom: 15px;
 }
 .docs .returns .description {
   margin-top: 15px;
@@ -436,7 +436,7 @@
       border-radius: 4px 4px 0 0;
       &:first-of-type {
         margin-left: 5px;
-      } 
+      }
     }
     li.tab.active {
       color: @clear;
@@ -451,6 +451,16 @@
       width: 100%;
       border: 1px solid @haze;
       border-radius: 6px;
+    }
+    .jsbin_link_wrapper {
+    	.pull-right;
+    	font-size: 14px;
+    	margin-top: 10px;
+
+    	i {
+    		padding-right: 5px;
+    		text-decoration: none;
+    	}
     }
   }
   body.style-demo {


### PR DESCRIPTION
A new option has been added to the `@demo` tag to show the link, by default it won't be shown.

```
@demo path/to/demo +jsbin
@demo path/to/demo 400 +jsbin
```

Also added some styles to it, it looks like this now:
![screen shot 2015-06-12 at 10 32 48](https://cloud.githubusercontent.com/assets/724877/8131287/a4ee69ee-10ef-11e5-989a-a13609f0c43b.png)

and when clicked, it opens up the html, js and output panels.
![screen shot 2015-06-11 at 08 57 52](https://cloud.githubusercontent.com/assets/724877/8107524/3e1cacd2-1020-11e5-9597-7589084e5bbc.png)

We should make sure our own demos lint correctly to avoid things like:
![screen shot 2015-06-11 at 09 12 50](https://cloud.githubusercontent.com/assets/724877/8107534/54e4b41e-1020-11e5-8f9c-e166411e2448.png)
