### PR TITLE
siteDefaults has to be outside 'sites'

### DIFF
--- a/docs/livestyleguide/guides/quickstart/custom-styles.md
+++ b/docs/livestyleguide/guides/quickstart/custom-styles.md
@@ -26,10 +26,10 @@ You'll need to tell DocumentJS to look for static resources in your theme folder
 Updated `documentjs.json`:
 ```json
 {
+    "siteDefaults": {
+      "static": "style-guide-theme"
+    },
     "sites": {
-        "siteDefaults": {
-            "static": "style-guide-theme"
-        },
         "styles": {
             "glob": "styles/**/*.{md,less,md}",
             "parent": "style-guide",


### PR DESCRIPTION
DocumentCSS guides currently show: 
![screen shot 2015-08-19 at 4 11 13 pm](https://cloud.githubusercontent.com/assets/326843/9369128/f0d85e64-468c-11e5-8775-4d4f72cd930c.png)

But the siteDefaults has to be outside the sites like this: 
````
{
  "siteDefaults": {
    "templates": "themes/classic/templates",
    "static": "themes/classic/static"
  },
    "sites": {
        "styles": {
            "glob": "less/**/*.{css,less,md},docs/**/*.{css,less,md}",
            "dest": "styleguide",
            "parent": "styles"
        }
    }
}
````