### PR TITLE
fixes #106 by adding HTML generated file warning helper

### DIFF
--- a/lib/generators/html/build/make_default_helpers.js
+++ b/lib/generators/html/build/make_default_helpers.js
@@ -163,6 +163,40 @@ module.exports = function(docMap, config, getCurrent, Handlebars){
 			}
 			return JSON.stringify(configCopy);
 		},
+
+		/**
+		 * @function documentjs.generators.html.defaultHelpers.generatedWarning
+		 * @signature `{{{generatedWarning}}}`
+		 * 
+		 * @body
+		 * 
+		 * ## Use
+		 * ```
+		 * {{{generatedWarning}}}
+		 * ```
+		 * MUST use triple-braces to escape HTML so it is hidden in a comment.
+		 *
+		 * Creates a warning that looks like this:
+		 *
+		 * ```
+		 * <!--####################################################################
+		 * THIS IS A GENERATED FILE -- ANY CHANGES MADE WILL BE OVERWRITTEN
+		 *
+		 * INSTEAD CHANGE:
+		 * source: lib/tags/iframe.js, line: 23
+		 * @@constructor documentjs.tags.iframe
+		 * ######################################################################## -->
+		 * ```
+		 */
+		generatedWarning: function(){
+			var current = getCurrent();
+			return "<!--####################################################################\n" +
+						 "\tTHIS IS A GENERATED FILE -- ANY CHANGES MADE WILL BE OVERWRITTEN\n\n" + 
+						 '\tINSTEAD CHANGE:\n' +
+						 "\tsource: " + current.src + (current.codeLine ? ', line: ' + current.codeLine : '') +
+						 (current.type ? '\n\t@' + current.type + " " + current.name : '') +
+						 "\n######################################################################## -->";
+		},
 		
 		getParentsPathToSelf: function(name){
 			var names = {};

--- a/lib/generators/html/build/make_default_helpers.js
+++ b/lib/generators/html/build/make_default_helpers.js
@@ -183,7 +183,7 @@ module.exports = function(docMap, config, getCurrent, Handlebars){
 		 * THIS IS A GENERATED FILE -- ANY CHANGES MADE WILL BE OVERWRITTEN
 		 *
 		 * INSTEAD CHANGE:
-		 * source: lib/tags/iframe.js, line: 23
+		 * source: lib/tags/iframe.js
 		 * @@constructor documentjs.tags.iframe
 		 * ######################################################################## -->
 		 * ```
@@ -193,7 +193,7 @@ module.exports = function(docMap, config, getCurrent, Handlebars){
 			return "<!--####################################################################\n" +
 						 "\tTHIS IS A GENERATED FILE -- ANY CHANGES MADE WILL BE OVERWRITTEN\n\n" + 
 						 '\tINSTEAD CHANGE:\n' +
-						 "\tsource: " + current.src + (current.codeLine ? ', line: ' + current.codeLine : '') +
+						 "\tsource: " + current.src +
 						 (current.type ? '\n\t@' + current.type + " " + current.name : '') +
 						 "\n######################################################################## -->";
 		},

--- a/site/default/templates/layout.mustache
+++ b/site/default/templates/layout.mustache
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+{{{generatedWarning}}}
 
 <!--[if lt IE 7]>
 <html class="no-js ie lt-ie9 lt-ie8 lt-ie7" lang="en">


### PR DESCRIPTION
fixes #106 
Adds a helper that can be used at the top of layout.mustache to generate an HTML comment at the top of every generated file.

Example:
<img width="664" alt="screen shot 2015-08-20 at 5 00 03 pm" src="https://cloud.githubusercontent.com/assets/412362/9396829/1d430db6-475d-11e5-8af9-360655f4dd5d.png">

Documentation page
<img width="687" alt="screen shot 2015-08-20 at 5 00 14 pm" src="https://cloud.githubusercontent.com/assets/412362/9396830/1d43878c-475d-11e5-9651-071a71aa0678.png">
