### PR TITLE
allows () in names

### DIFF
--- a/lib/tags/helpers/typeNameDescription.js
+++ b/lib/tags/helpers/typeNameDescription.js
@@ -15,8 +15,6 @@ module.exports = function(line, ignoreName){
 	var children = typer.tree(line),
 		param = {};
 
-
-	console.log(children);
 	var textIs = function(i,text){
 		return children[i] && children[i].token == text;
 	};

--- a/lib/tags/helpers/typeNameDescription.js
+++ b/lib/tags/helpers/typeNameDescription.js
@@ -2,12 +2,21 @@
 var namer = require("./namer"),
 	typer = require("./typer");
 	
-	
+/**
+ * @hide
+ * 
+ * This is used to parse out content like `{TYPE} name() description`.
+ * 
+ * @param {String} line
+ * @param {Bolean} ignoreName If true, only looks for a TYPE in curlies followed by a description.
+ */
 module.exports = function(line, ignoreName){
 
 	var children = typer.tree(line),
 		param = {};
 
+
+	console.log(children);
 	var textIs = function(i,text){
 		return children[i] && children[i].token == text;
 	};
@@ -29,8 +38,8 @@ module.exports = function(line, ignoreName){
 			namer.process( nameChildren, param);
 		}
 		
-		param.description = children[index] ?
-			line.substr( children[index].start ) : ""
+		param.description = (children[index] ?
+			line.substr( children[index].start ) : "").replace(/\\/g,"");
 	};
 	
 	

--- a/lib/tags/helpers/typeNameDescription_test.js
+++ b/lib/tags/helpers/typeNameDescription_test.js
@@ -18,6 +18,12 @@ describe("documentjs/tags/helpers/typeNameDescription",function(){;
 		assert.equal(res.description, "description")
 	});
 	
+	it("handles () in description (#168)", function(){
+		var res = tnd("@foo name \\(E\\)");
+		assert.equal(res.description, "(E)");
+		
+	});
+	
 	/*test("has a function in it", function(){
 		
 		var res = tnd("@param {String} \... description");


### PR DESCRIPTION
#168  This is mostly a hack to allow () in names.  You can escape () by writing `\\(\\)`.  If you do this, we need to remove the `\\` after you do this.  This enables that.