### PR TITLE
Use the specific supported version of Node in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
-  - "node"
+  - "0.12"
   - "iojs"
 script: npm test
 sudo: false


### PR DESCRIPTION
Current we support 0.10, 0.12, and iojs, so updating Travis to reflect
that.

Fixes #210