### PR TITLE
Dynamically get available port for connect server

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/lib/configured/configured_test.js
+++ b/lib/configured/configured_test.js
@@ -6,7 +6,8 @@ var configured = require("./configured"),
 
 var Browser = require("zombie"),
 	connect = require("connect"),
-	rmdir = require('rimraf');
+	getPort = require("get-port"),
+	rmdir = require("rimraf");
 
 
 var find = function(browser, property, callback, done){
@@ -38,17 +39,20 @@ var waitFor = function(browser, checker, callback, done){
 
 
 var open = function(url, callback, done){
-	var server = connect().use(connect.static(path.join(__dirname))).listen(8081);
-	var browser = new Browser();
-	browser.visit("http://localhost:8081/"+url)
-		.then(function(){
-			callback(browser, function(){
+	getPort().then(function(port){
+		var server = connect().use(connect.static(path.join(__dirname))).listen(port);
+		var browser = new Browser();
+
+		browser.visit("http://localhost:"+port+"/"+url)
+			.then(function(){
+				callback(browser, port, function(){
+					server.close();
+				})
+			}).catch(function(e){
 				server.close();
-			})
-		}).catch(function(e){
-			server.close();
-			done(e)
-		});
+				done(e)
+			});
+	});
 };
 
 
@@ -173,13 +177,13 @@ describe("lib/configured", function(){
 	it(".generateProject is able to document multiple versions", function(done){
 		// switch from old to old
 		var check1 = function(next, done){
-			open("test/tmp/multiple_versions/1.0.0/api/index.html",function(browser, close){
+			open("test/tmp/multiple_versions/1.0.0/api/index.html",function(browser, port, close){
 				var select = browser.window.document.getElementsByTagName("select")[0],
 					$ = browser.window.$;
 					$(select).val("3.0.0").trigger("change");
 
 					waitFor(browser, function(window){
-						return window.location.href == "http://localhost:8081/test/tmp/multiple_versions/3.0.0/api/index.html"
+						return window.location.href == "http://localhost:"+port+"/test/tmp/multiple_versions/3.0.0/api/index.html"
 					}, function(){
 						assert.ok(true,"updated page");
 						close();
@@ -190,13 +194,13 @@ describe("lib/configured", function(){
 		};
 		// switch from new to old
 		var check2 = function(next, done){
-			open("test/tmp/multiple_versions/api/index.html",function(browser, close){
+			open("test/tmp/multiple_versions/api/index.html",function(browser, port, close){
 				var select = browser.window.document.getElementsByTagName("select")[0],
 					$ = browser.window.$;
 					$(select).val("3.0.0").trigger("change");
 
 					waitFor(browser, function(window){
-						return window.location.href == "http://localhost:8081/test/tmp/multiple_versions/3.0.0/api/index.html"
+						return window.location.href == "http://localhost:"+port+"/test/tmp/multiple_versions/3.0.0/api/index.html"
 					}, function(){
 						assert.ok(true,"updated page");
 						close();
@@ -207,13 +211,13 @@ describe("lib/configured", function(){
 		};
 		// check old to new
 		var check3 = function(next, done){
-			open("test/tmp/multiple_versions/3.0.0/api/index.html",function(browser, close){
+			open("test/tmp/multiple_versions/3.0.0/api/index.html",function(browser, port, close){
 				var select = browser.window.document.getElementsByTagName("select")[0],
 					$ = browser.window.$;
 					$(select).val("2.0.0").trigger("change");
 
 					waitFor(browser, function(window){
-						return window.location.href == "http://localhost:8081/test/tmp/multiple_versions/api/index.html"
+						return window.location.href == "http://localhost:"+port+"/test/tmp/multiple_versions/api/index.html"
 					}, function(){
 						assert.ok(true,"updated page");
 						close();
@@ -247,7 +251,7 @@ describe("lib/configured", function(){
 			}
 
 			configured.generateProject({path: __dirname+"/test/multiple_versions"}, undefined, {only:[{name:"master"}]}).then(function(){
-				open("test/tmp/multiple_versions/api/index.html",function(browser, close){
+				open("test/tmp/multiple_versions/api/index.html",function(browser, port, close){
 					assert.ok(true,"page built and opened");
 					done();
 					close();
@@ -304,7 +308,7 @@ describe("lib/configured", function(){
 	it("is able to change where versions is located", function(done){
 		this.timeout(10000);
 		var check = function(done){
-			open("test/tmp/version_placement/1.0.0/api/index.html",function(browser, close){
+			open("test/tmp/version_placement/1.0.0/api/index.html",function(browser, port, close){
 				var option = browser.window.document.getElementsByTagName("option")[0];
 
 				assert.equal(option.text || option.textContent, "Project 1.0.0");
@@ -333,7 +337,7 @@ describe("lib/configured", function(){
 		this.timeout(20000);
 		// check that docObjects has a returns
 		var check = function(done){
-			open("test/tmp/custom_tags/index.html",function(browser, close){
+			open("test/tmp/custom_tags/index.html",function(browser, port, close){
 
 				var rets = browser.window.document.getElementsByClassName("returns")
 

--- a/lib/generate/test/generate_test.js
+++ b/lib/generate/test/generate_test.js
@@ -3,6 +3,7 @@ var generate = require("../generate"),
 	rmdir = require('rimraf'),
 	Browser = require("zombie"),
 	connect = require("connect"),
+	getPort = require("get-port"),
 	path = require("path"),
 	slash = require("../../slash");
 	
@@ -22,18 +23,21 @@ var find = function(browser, property, callback, done){
 };
 
 var open = function(url, callback, done){
-	var server = connect().use(connect.static(path.join(__dirname))).listen(8081);
-	var browser = new Browser();
-	browser.visit("http://localhost:8081/"+url)
-		.then(function(){
-			callback(browser, function(){
+	getPort().then(function(port){
+		var server = connect().use(connect.static(path.join(__dirname))).listen(port);
+		var browser = new Browser();
+
+		browser.visit("http://localhost:"+port+"/"+url)
+			.then(function(){
+				callback(browser, function(){
+					server.close();
+					done();
+				})
+			}).catch(function(e){
 				server.close();
-				done();
-			})
-		}).catch(function(e){
-			server.close();
-			done(e)
-		});
+				done(e)
+			});
+	});
 };
 	
 describe("documentjs/lib/generate/generate",function(){

--- a/lib/test_helpers.js
+++ b/lib/test_helpers.js
@@ -1,5 +1,6 @@
 var Browser = require("zombie"),
-	connect = require("connect");
+	connect = require("connect"),
+	getPort = require("get-port");
 
 
 
@@ -33,17 +34,20 @@ var waitFor = function(browser, checker, callback, done){
 
 
 var open = function(url, callback, done){
-	var server = connect().use(connect.static(path.join(__dirname))).listen(8081);
-	var browser = new Browser();
-	browser.visit("http://localhost:8081/"+url)
-		.then(function(){
-			callback(browser, function(){
+	getPort().then(function(port){
+		var server = connect().use(connect.static(path.join(__dirname))).listen(port);
+		var browser = new Browser();
+		
+		browser.visit("http://localhost:"+port+"/"+url)
+			.then(function(){
+				callback(browser, function(){
+					server.close();
+				})
+			}).catch(function(e){
 				server.close();
-			})
-		}).catch(function(e){
-			server.close();
-			done(e)
-		});
+				done(e)
+			});
+	});
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "release:major": "npm version major && npm publish"
   },
   "devDependencies": {
+    "connect": "^2.14.4",
+    "get-port": "^2.1.0",
     "mocha": ">= 1.18.0",
     "qunit-mocha-ui": "*",
-    "rimraf": "2.1",
-    "connect": "^2.14.4"
+    "rimraf": "2.1"
   },
   "dependencies": {
     "md5": "^2.0.0",


### PR DESCRIPTION
Adds the get-port module to dev dependencies and uses it to dynamically get an available port for the connect server used by unit tests.

This avoid port-in-use errors and fixes #229

Also contains the necessary `.gitattributes` setting to work around #228 
