### PR TITLE
Correctly name mustache files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "iojs"
+  - "node"
 script: npm test
 sudo: false

--- a/lib/process/file.js
+++ b/lib/process/file.js
@@ -91,7 +91,7 @@ module.exports = function processFile(source, docMap, filename, options ) {
 			scope: scope,
 			docObject: makeDocObject({
 				type: 'page',
-				name: (filename+"").match(/([^\/]+)\.(md|markdown)$/)[1]
+				name: (filename+"").match(/([^\\\/]+)\.(md|markdown)$/)[1]
 			}),
 			tags: options.tags
 		}, typeCreateHandler);
@@ -99,7 +99,7 @@ module.exports = function processFile(source, docMap, filename, options ) {
 		return;
 	} else if( /\.(mustache|handlebars)$/.test(filename) ) {
 		typeCreateHandler(makeDocObject({
-			name: (filename+"").match(/([^\/]+)\.(mustache|handlebars)$/)[1],
+			name: (filename+"").match(/([^\\\/]+)\.(mustache|handlebars)$/)[1],
 			renderer: function(data, originalRenderer){
 				var contentRenderer = originalRenderer.Handlebars.compile(source);
 				var content = contentRenderer(data);

--- a/lib/process/process_test.js
+++ b/lib/process/process_test.js
@@ -54,10 +54,10 @@ var process = require("./process"),
 
 
 		describe(".comment", function(){
-			
+
 			it("adds to parent",function(){
 				var docMap = {Foo: {name: "Foo",type: "constructor"}};
-	
+
 				process.comment({
 					comment: "@property {Object} tags Tags for something",
 					scope: docMap.Foo,
@@ -69,7 +69,7 @@ var process = require("./process"),
 					assert.equal(newDoc.name, "Foo.tags");
 				});
 			});
-	
+
 			it("change scope", function(){
 				var tags = {
 					constructor: {
@@ -86,10 +86,10 @@ var process = require("./process"),
 					},
 					property: propertyTag
 				};
-	
+
 				var docMap = {Foo: {name: "Foo",type: "constructor"}},
 					props = {};
-	
+
 				process.comment({
 					comment:   ["@constructor",
 								"@parent tang"],
@@ -100,7 +100,7 @@ var process = require("./process"),
 				},function(newDoc, newScope){
 					assert.equal(newDoc, newScope, "new doc item is new scope");
 					assert.equal(newDoc, props, "props is the new doc object");
-	
+
 					assert.deepEqual(newDoc,{
 						name: "constructed",
 						type: "constructor",
@@ -109,9 +109,9 @@ var process = require("./process"),
 						description: ""
 					});
 				});
-	
+
 			});
-			
+
 			var example = {
 				add: function(line){
 					return {
@@ -125,11 +125,11 @@ var process = require("./process"),
 					this.body += "```\n"+curData.lines.join("\n")+"\n```\n";
 				}
 			};
-			
+
 			it("is able to end a current tag", function(){
 
 				var docMap = {Foo: {name: "Foo",type: "constructor"}};
-	
+
 				process.comment({
 					comment: [
 						"@property {Object} tags Tags for something",
@@ -147,7 +147,7 @@ var process = require("./process"),
 					docMap: docMap,
 					docObject: {},
 					tags: {
-						property: propertyTag, 
+						property: propertyTag,
 						example: example,
 						body: {
 							add: function( line ) {
@@ -158,12 +158,12 @@ var process = require("./process"),
 				},function(newDoc, newScope){
 					assert.equal(newDoc.body, '\nbody\n```\n_.extend()\n```\n```\n_.clone()\n```\nendbody\n');
 				});
-				
+
 			});
-			
+
 			it("ends a current tag that is the last tag",function(){
 				var docMap = {Foo: {name: "Foo",type: "constructor"}};
-	
+
 				process.comment({
 					comment: [
 						"@property {Object} tags Tags for something",
@@ -177,7 +177,7 @@ var process = require("./process"),
 					docMap: docMap,
 					docObject: {},
 					tags: {
-						property: propertyTag, 
+						property: propertyTag,
 						example: example,
 						body: {
 							add: function( line ) {
@@ -189,54 +189,54 @@ var process = require("./process"),
 					assert.equal(newDoc.body, '\nbody\n```\n_.extend()\n```\n');
 				});
 			});
-			
+
 			it("handles indentation", function(done){
 				fs.readFile(
-					path.join(__dirname,"test","indentation.md"), 
+					path.join(__dirname,"test","indentation.md"),
 					function(err, content){
-						
+
 						if(err) {
 							return done(err);
 						}
-						
+
 						var docMap = {};
-						
+
 						process.comment({
 							comment: ""+content,
 							scope: {},
 							docMap: docMap,
 							docObject: {}
 						},function(newDoc, newScope){
-							
+
 							var options = newDoc.params[0].types[0].options,
 								func = options[0].types[0],
 								returns = func.returns;
-							
+
 							// return indentation
 							assert.deepEqual(returns.types[0], {type:"Boolean"},"return indented inside function option");
 							assert.deepEqual(newDoc.returns.types[0], {type: "String"}, "not indented normal return still works");
-							
+
 							// option
 							var barOptions = options[1].types[0].options;
 							assert.deepEqual(barOptions, [
 								{name: "first", types: [{type: "String"}], description: "\n"},
 								{name: "second", types: [{type: "String"}], description: "\n"}
 							]);
-							
+
 							// param
 							assert.equal(func.params[0].description, "newName description.\n", "params in params");
-							
+
 							// context / @this
 							assert.equal(func.context.description,"An object\na\n", "a description");
-							
+
 							done();
 						});
-						
+
 					});
 			});
-		
+
 		});
-		
+
 
 		it(".code",function(){
 			var tags = {
@@ -275,8 +275,8 @@ var process = require("./process"),
 
 			});
 		});
-		
-		
+
+
 
 		var makeDescription = function( comment, cb ){
 			var docMap = {Foo: {name: "Foo",type: "constructor"}},
@@ -355,6 +355,17 @@ var process = require("./process"),
 			assert.equal(result,"foo", "got back holler");
 		});
 
+        it("correctly names nested files", function(){
+            var docMap = {};
+            var mustache = path.join("docs","theme","templates","layout.mustache");
+            process.file("{{name}}", docMap, mustache);
+            assert.ok(docMap.layout, "got mustache");
+
+            var markdown = path.join("nested", "viewmodel.md");
+            process.file("/* */", docMap, markdown);
+            assert.ok(docMap.viewmodel, "got markdown");
+        });
+
 		it("end is not called twice", function(){
 			var docMap = {};
 			var timesCalled = 0;
@@ -432,7 +443,7 @@ var process = require("./process"),
 				done();
 			});
 		});
-		
+
 		it("process.getComments is able to get a comment directly after another comment (#62)", function(done){
 			fs.readFile(path.join(__dirname,"test","comment_after_comment.js"), function(err, data){
 				if(err) {
@@ -448,7 +459,7 @@ var process = require("./process"),
 				], result);
 				done();
 			});
-			
+
 		});
 
 		it("process.file provides filename and line if available to tags", function(done){
@@ -461,20 +472,20 @@ var process = require("./process"),
 					assert.equal(typeof this.line, "number","a line");
 				}
 			};
-			
+
 			fs.readFile(path.join(__dirname,"test","filename_and_line.js"), function(err, data){
 				if(err) {
 					return done(err);
 				}
-				
+
 				var docMap = {};
 				process.file(""+data,docMap,"utils/date-helpers.js");
 				done();
 			});
-			
+
 		});
-		
-		
+
+
 		it(".code keeps options.docObject's src and  line", function(done){
 			var count = 0;
 			tags.filetest = {
@@ -494,12 +505,12 @@ var process = require("./process"),
 					};
 				}
 			};
-			
+
 			fs.readFile(path.join(__dirname,"test","filename_and_line.js"), function(err, data){
 				if(err) {
 					return done(err);
 				}
-				
+
 				var docMap = {};
 				process.file(""+data,docMap,"utils/date-helpers.js");
 				done();


### PR DESCRIPTION
This files the naming of mustache files (and markdown files) on the
docMap, for Windows. The name is meant to be the last part of the path,
  minus the file extension, but was assuming Unix path separator.

This closes #238