### PR TITLE
Fix race condition in creating the static build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+; Unix-style newlines
+[*]
+end_of_line = LF
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = false

--- a/lib/generators/html/build/static_dist.js
+++ b/lib/generators/html/build/static_dist.js
@@ -54,12 +54,15 @@ module.exports = function(options){
 		
 		var distFolder = path.join("site","static","dist", hash),
 			buildFolder = path.join("site","static","build", hash);
-		
-		return Q.all([
+
+		var mkdirPromise = Q.all([
 			fss.mkdirs(distFolder),
-			fss.mkdirs(buildFolder),
-			fss.exists(path.join(distFolder,"bundles","static.css")).then(function(exists){
-	
+			fss.mkdirs(buildFolder)
+		]);
+		
+		return mkdirPromise.then(function(){
+			return fss.exists(path.join(distFolder,"bundles","static.css"))
+			.then(function(exists){
 				// If we have already built, don't build again
 				if(exists && !options.forceBuild) {
 					builtAlready = true;
@@ -70,13 +73,14 @@ module.exports = function(options){
 					return;
 				}
 	
-				return fss.copy( path.join("site","default","static"),buildFolder).then(function(){
+				return fss.copy(path.join("site","default","static"), buildFolder)
+				.then(function(){
 					if(options["static"]){
 						return fss.copyFrom(options["static"], buildFolder);
 					} 
 				});
-			})
-		]).then(function(){
+			});
+		}).then(function(){
 			if(builtAlready){
 				return;
 			}


### PR DESCRIPTION
This fixes #243

The cause of the bug was that we were making the dist and build folders
at the same time that we were trying to copy the static.css into the
build folder. So the error would occur when things happened in this
order:

1. dist folder created
2. stat to check if dist/bundles/static.css exists (it won't)
3. copy the default static folder into the build folder
4. build folder is created

Error occurs when 3 occurs before 4.

Restructured the code so that we make the folders before trying the copy
procedure.