### PR TITLE
Use the npm cli rather than the npm module

### DIFF
--- a/lib/configured/get_project.js
+++ b/lib/configured/get_project.js
@@ -1,4 +1,4 @@
-var npm = require("npm");
+var npm = require("./npm/npm");
 var	fs = require('fs-extra');
 
 var path = require("path");
@@ -72,28 +72,17 @@ module.exports = function(project){
 			});
 
 	} else if(project.npmInstall === true) {
-		var npmDeferred = Q.defer();
+		var installPromise = npm.installInPath(__dirname+"/tmp", process.source);
 
-		npm.load({
-		    loaded: false
-		}, function (err) {
-		  // catch errors
-			npm.commands.install(__dirname+"/tmp",[project.source], function(err, data){
-				if(err) {
-					npmDeferred.reject(err);
-				} else {
-					npmDeferred.resolve(data);
-				}
-			});
-		});
-
-		return Q.all([removePromise, npmDeferred.promise]).then(function(){
+		return Q.all([removePromise, installPromise]).then(function(){
 			return move(
 				path.join(__dirname,"/tmp/node_modules",projectName),
 				finalDest);
 		});
 	} else {
 		var ghDownloadDeferred = Q.defer();
+		var resolve = ghDownloadDeferred.resolve.bind(ghDownloadDeferred);
+		var reject = ghDownloadDeferred.reject.bind(ghDownloadDeferred);
 		return removePromise.then(function(){
 			console.log("downloading",project.source);
 			ghdownload(project.source, finalDest)
@@ -106,17 +95,10 @@ module.exports = function(project){
 				})
 				.on('end', function(){
 					if(project.npmInstall) {
-						npmInstall(finalDest, project.npmInstall, function(err, data){
-							if(err) {
-								ghDownloadDeferred.reject(err);
-							} else {
-								ghDownloadDeferred.resolve(data);
-							}
-						});
+						npm.installInPath(finalDest, project.npmInstall)
+							.then(resolve, reject);
 
 					} else {
-
-
 						fs.readFile(path.join(finalDest,"package.json"), function(err, source) {
 							if(err) {
 								ghDownloadDeferred.resolve();
@@ -134,13 +116,8 @@ module.exports = function(project){
 									installs.push(name+"@"+packageJSON.docDependencies[name]);
 								}
 
-								npmInstall(finalDest, installs, function(err, data){
-									if(err) {
-										ghDownloadDeferred.reject(err);
-									} else {
-										ghDownloadDeferred.resolve(data);
-									}
-								});
+								npm.installInPath(finalDest, installs)
+									.then(resolve, reject);
 							} else {
 								ghDownloadDeferred.resolve();
 							}
@@ -152,26 +129,5 @@ module.exports = function(project){
 			return ghDownloadDeferred.promise;
 		});
 	}
-
-};
-
-
-
-var npmInstall = function(finalDest, installs, callback ) {
-
-	npm.load({
-	    loaded: false,
-        "onload-script": false,
-        "script-ssl": false,
-        "registry": "http://registry.npmjs.org"
-	}, function (err) {
-		if(err) {
-			console.error("Unable to load npm:", err);
-			return callback(err);
-		}
-
-		console.log("npm install", installs);
-		npm.commands.install( finalDest, installs, callback);
-	});
 
 };

--- a/lib/configured/npm/npm.js
+++ b/lib/configured/npm/npm.js
@@ -1,0 +1,49 @@
+var Q = require("q");
+var path = require("path");
+var spawn = require("cross-spawn-async");
+var mkdirs = Q.denodeify(require("fs-extra").mkdirs);
+
+exports.installInPath = function(pth, module, version){
+	var cwd = process.cwd();
+	pth = path.resolve(pth);
+	process.chdir(pth);
+
+	var nmPth = path.join(pth, "node_modules");
+
+	return mkdirs(nmPth).then(function(){
+		return exports.install(module, version);
+	}).then(function(res){
+		process.chdir(cwd);
+		return res;
+	});
+};
+
+exports.install = function(module, version){
+	if(version) {
+		module = module + "@" + version;
+	}
+	if(!Array.isArray(module)) {
+		module = [ module ];
+	}
+
+	return exports.runCommand(["install"].concat(module));
+};
+
+exports.runCommand = function(args){
+	var child = spawn("npm", args, {
+		cwd: process.cwd(),
+		stdio: "inherit"
+	});
+
+	var deferred = Q.defer();
+
+	child.on("exit", function(status){
+		if(status) {
+			deferred.reject(new Error("Command `npm` did not complete successfully"));
+		} else {
+			deferred.resolve(child);
+		}
+	});
+	
+	return deferred.promise;
+}

--- a/lib/configured/npm/npm_test.js
+++ b/lib/configured/npm/npm_test.js
@@ -1,0 +1,32 @@
+var assert = require("assert");
+var npm = require("./npm");
+
+describe("npm utility", function(){
+	describe("npm.install", function(){
+		beforeEach(function(){
+			this.runCommand = npm.runCommand;
+		});
+
+		afterEach(function(){
+			npm.runCommand = this.runCommand;
+		});
+
+		it("Runs the right command to install", function(){
+			npm.runCommand = function(args){
+				assert.equal(args[0], "install", "calling install");
+				assert.equal(args[1], "foobar", "installing foobar");
+			};
+
+			npm.install("foobar");
+		});
+
+		it("Runs the right command to install a version", function(){
+			npm.runCommand = function(args){
+				assert.equal(args[0], "install", "calling install");
+				assert.equal(args[1], "foobar@^2.0.0", "installing foobar");
+			};
+
+			npm.install("foobar", "^2.0.0");
+		});
+	});
+});

--- a/package.json
+++ b/package.json
@@ -29,25 +29,25 @@
     "connect": "^2.14.4"
   },
   "dependencies": {
-    "md5": "^2.0.0",
     "async": "~0.2.7",
     "can": "2.3.8",
     "chokidar": "^1.0.0-rc5",
+    "cross-spawn-async": "^2.1.9",
+    "documentjs-github-download": "^0.3.0",
+    "engine-dependencies": "^0.2.0",
     "esprima": "~2.5.0",
     "fs-extra": "^0.24.0",
-    "documentjs-github-download": "^0.3.0",
     "glob": "~6.0.3",
     "handlebars": "1.0.10",
     "jquery": "~1.11.0",
     "less": "^1.7.0",
     "lodash": "~2.4.1",
+    "md5": "^2.0.0",
     "minimatch": "~1.0.0",
-    "npm": "^2.14.1",
     "q": "~1.0.1",
     "steal": "0.13.X",
     "steal-tools": "0.13.X",
-    "yargs": "^1.3.1",
-    "engine-dependencies": "^0.2.0"
+    "yargs": "^1.3.1"
   },
   "engineDependencies": {
     "node": {

--- a/test.js
+++ b/test.js
@@ -10,6 +10,8 @@ require("./lib/generate/test/generate_test");
 
 require("./lib/configured/configured_test");
 
+require("./lib/configured/npm/npm_test");
+
 var assert = require("assert");
 var docjs = require("./main.js");
 


### PR DESCRIPTION
This changes configured/get_project to use the npm cli (by spawning a
process) rather than the npm module. The reason is primarily so
that we support the version of npm that the user is using.

Closes #244