### PR TITLE
Fix package resolution when DocumentJS is run globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "md5": "^2.0.0",
     "minimatch": "~1.0.0",
     "q": "~1.0.1",
+    "resolve": "^1.4.0",
     "steal": "0.16.X",
     "steal-stache": "^3.0.7",
     "steal-tools": "0.16.X",

--- a/site/default/static/build.js
+++ b/site/default/static/build.js
@@ -1,6 +1,7 @@
 var assign = require("can-util/js/assign/assign");
 var fs = require('fs');
 var map = require('./map');
+var resolve = require('resolve');
 var stealTools = require("steal-tools"),
 	fsx = require('../../../../lib/fs_extras'),
 	Q = require('q'),
@@ -38,8 +39,10 @@ module.exports = function(options, folders){
 				// map[packageName] can either be just a string (e.g. jquery) or
 				// an object, so we want the path for the module, not an object
 				var resolvePath = (typeof map[packageName] === 'object') ? map[packageName][packageName] : map[packageName];
-				if (!resolvePath) {// Fall back to Node’s resolution for npm 3+
-					resolvePath = require.resolve(packageName);
+				if (!resolvePath) {
+					// Fall back to Node’s resolution for npm 3+
+					// …or the “resolve” package’s resolution implementation
+					resolvePath = require.resolve(packageName) || resolve.sync(packageName, {basedir: process.cwd()});
 				}
 
 				// Get the path relative to the build folder


### PR DESCRIPTION
Previously, when DocumentJS was installed globally and run, it wouldn’t be able to find packages in the project where the user was running the command.

This adds a fallback to using [resolve](https://www.npmjs.com/package/resolve)’s implementation of Node’s algorithm in the user’s current working directory.

I tested this by installing this fixed version globally and running the global command in a project that wasn’t working before. __I would appreciate some help figuring out how I should write a test for this case!__

Fixes https://github.com/bitovi/documentjs/issues/275