### PR TITLE
:bug: fix including multiple demos

### DIFF
--- a/site/default/static/frame_helper.js
+++ b/site/default/static/frame_helper.js
@@ -29,9 +29,6 @@ module.exports = CanControl.extend({
 			var wrapper = $(this);
 			new DemoFrame(wrapper);
 			
-			if(wrapper.data('demoHeight')) {
-				iframe.height(wrapper.data('demoHeight'));
-			}
 		});
 	}
 });


### PR DESCRIPTION
adding multiple Demos in the same md file appears not to work. there are some issues with
"demo_frame"
this part of the code
```
$('.demo_wrapper', this.element).each(function() {
	var wrapper = $(this);
	new DemoFrame(wrapper);
				
	if(wrapper.data('demoHeight')) {
		iframe.height(wrapper.data('demoHeight'));
	}
});
```
it is clear that iframe dose not exest in this context.