### PR TITLE
Fix error with demo tags on generated documentation

### DIFF
--- a/lib/generators/html/write/filename.js
+++ b/lib/generators/html/write/filename.js
@@ -1,9 +1,6 @@
 module.exports = function(docObject, configuration){
 	var name = typeof docObject == "string" ? docObject : docObject.name;
 
-	if(!name) {
-		debugger;
-	}
 	return configuration && name === configuration.parent ?
 		'index.html' :
 		name.replace(/ /g, "_")

--- a/site/default/static/frame_helper.js
+++ b/site/default/static/frame_helper.js
@@ -1,5 +1,5 @@
-var CanControl = require("can-control");
 var $ = require("jquery");
+var CanControl = require("can-control");
 var DemoFrame = require("./demo_frame");
 
 module.exports = CanControl.extend({
@@ -26,9 +26,7 @@ module.exports = CanControl.extend({
 		// @demo can/control/control.html 400
 		// <div class="demo_wrapper" data-demo-src="can/control/control.html"></div>
 		$('.demo_wrapper', this.$element).each(function() {
-			var wrapper = $(this);
-			new DemoFrame(wrapper);
-			
+			new DemoFrame(this);
 		});
 	}
 });

--- a/site/default/static/static.js
+++ b/site/default/static/static.js
@@ -1,3 +1,4 @@
+var $ = require("jquery");
 var ContentList = require("./content_list");
 var FrameHelper = require("./frame_helper");
 var Versions = require("./versions");


### PR DESCRIPTION
Why?
The previous release of documentjs upgrade to can-control@3.x but it did not account for the fact that the DemoFrame control was instantiated with a jquery element which is no longer natively supported
in 3.x; this cause can-event to try to call `.addEventListener` on a jquery-wrapped element which threw an error.

This is fixed by:
Make sure the control is instantiated with an HtmlElement instead of a jquery-wrapped element.

Closes #287

![screen shot 2019-01-09 at 4 05 24 pm](https://user-images.githubusercontent.com/724877/50935387-192b6600-1429-11e9-8e57-87ac7e988eff.png)
